### PR TITLE
Region failover backtracking2

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -1777,7 +1777,7 @@ public class ExecutionGraph implements AccessExecutionGraph, FailoverTopology {
 	}
 
 	@Override
-	public boolean containsIterations() {
+	public boolean containsColocationConstraints() {
 		return getAllVertices().values().stream()
 			.map(ExecutionJobVertex::getCoLocationGroup)
 			.anyMatch(Objects::nonNull);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
@@ -35,7 +35,6 @@ import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
 import org.apache.flink.runtime.execution.ExecutionState;
-import org.apache.flink.runtime.executiongraph.failover.flip1.FailoverEdge;
 import org.apache.flink.runtime.executiongraph.failover.flip1.FailoverVertex;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
@@ -75,7 +74,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static org.apache.flink.runtime.execution.ExecutionState.FINISHED;
@@ -950,19 +948,19 @@ public class ExecutionVertex implements AccessExecutionVertex, Archiveable<Archi
 	}
 
 	@Override
-	public Collection<FailoverEdge> getInputEdges() {
-		return IntStream.range(0, getNumberOfInputs())
+	public Iterable<ExecutionEdge> getInputEdges() {
+		return () -> IntStream.range(0, getNumberOfInputs())
 			.mapToObj(this::getInputEdges)
 			.flatMap(Arrays::stream)
-			.collect(Collectors.toList());
+			.iterator();
 	}
 
 	@Override
-	public Collection<FailoverEdge> getOutputEdges() {
-		return resultPartitions.values().stream()
+	public Iterable<ExecutionEdge> getOutputEdges() {
+		return () -> resultPartitions.values().stream()
 			.map(IntermediateResultPartition::getConsumers)
 			.flatMap(Collection::stream)
 			.flatMap(Collection::stream)
-			.collect(Collectors.toList());
+			.iterator();
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
@@ -946,7 +946,7 @@ public class ExecutionVertex implements AccessExecutionVertex, Archiveable<Archi
 
 	@Override
 	public String getExecutionVertexName() {
-		return getTaskName();
+		return getTaskNameWithSubtaskIndex();
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/FailoverRegion.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/FailoverRegion.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.executiongraph.failover.flip1;
 
 import org.apache.flink.util.AbstractID;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/FailoverRegion.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/FailoverRegion.java
@@ -48,7 +48,7 @@ public class FailoverRegion {
 	}
 
 	/**
-	 * get IDs of all execution vertex IDs in this region
+	 * get IDs of all execution vertex IDs in this region.
 	 */
 	public Set<AbstractID> getAllExecutionVertexIDs() {
 		return executionVertexIDs;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/FailoverTopology.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/FailoverTopology.java
@@ -29,5 +29,5 @@ public interface FailoverTopology {
 	 */
 	Iterable<? extends FailoverVertex> getFailoverVertices();
 
-	boolean containsIterations();
+	boolean containsColocationConstraints();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/FailoverVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/FailoverVertex.java
@@ -19,8 +19,6 @@ package org.apache.flink.runtime.executiongraph.failover.flip1;
 
 import org.apache.flink.util.AbstractID;
 
-import java.util.Collection;
-
 /**
  * Represents an ExecutionVertex.
  */
@@ -42,12 +40,12 @@ public interface FailoverVertex {
 	 *
 	 * @return input edges of this vertex
 	 */
-	Collection<FailoverEdge> getInputEdges();
+	Iterable<? extends FailoverEdge> getInputEdges();
 
 	/**
 	 * Returns all output edges of this vertex.
 	 *
 	 * @return output edges of this vertex
 	 */
-	Collection<FailoverEdge> getOutputEdges();
+	Iterable<? extends FailoverEdge> getOutputEdges();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/RestartPipelinedRegionStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/RestartPipelinedRegionStrategy.java
@@ -71,7 +71,7 @@ public class RestartPipelinedRegionStrategy implements FailoverStrategy {
 	private void buildFailoverRegions() {
 		// currently we let a job with co-location constraints fail as one region
 		// putting co-located vertices in the same region with each other can be a future improvement
-		if (topology.containsIterations()) {
+		if (topology.containsColocationConstraints()) {
 			buildOneRegionForAllVertices();
 			return;
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/RestartPipelinedRegionStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/RestartPipelinedRegionStrategy.java
@@ -47,7 +47,7 @@ public class RestartPipelinedRegionStrategy implements FailoverStrategy {
 	/** The topology containing info about all the vertices and edges. */
 	private final FailoverTopology topology;
 
-	/** Maps execution vertex id to failover region */
+	/** Maps execution vertex id to failover region. */
 	private final Map<AbstractID, FailoverRegion> regions;
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/RestartPipelinedRegionStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/RestartPipelinedRegionStrategy.java
@@ -19,6 +19,7 @@ package org.apache.flink.runtime.executiongraph.failover.flip1;
 
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.util.AbstractID;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 


### PR DESCRIPTION
Some small checkstyle cleanups, along with the discussed changes:
* include subtask index in task name
* return iterable for the input/output edges

Returning an iterable has the nice side-effect that they the streams are evaluated lazily.